### PR TITLE
WPCS-15: Update contact form background and text

### DIFF
--- a/_sass/partials/modules/_contractors-view.scss
+++ b/_sass/partials/modules/_contractors-view.scss
@@ -60,10 +60,8 @@
 }
 
 .contact-form {
-  background: linear-gradient(0deg, $newblue--light 0%, $grey--lightest);
-  background-repeat: no-repeat;
-  background-position: bottom;
-  background-size: 100%;
+  background: $newblue--light;
+  color: $white;
   margin-top: 3rem;
   padding-top: 5rem;
 


### PR DESCRIPTION
Update background to not use gradient anymore and updated text to white.

https://trello.com/c/t9M36aB9/15-need-to-add-form-to-the-bottom-of-new-wp-contractors-static-site-landing-pages